### PR TITLE
Extended online monitoring of DWCs

### DIFF
--- a/producers/cmshgcal/STARTRUN_ALL
+++ b/producers/cmshgcal/STARTRUN_ALL
@@ -110,7 +110,7 @@ xterm -sb -sl 1000 -geom 80x600-280-900 -fn fixed -T "RPI Producer" -e './RpiPro
 #nohup ./HGCalProducer.exe -r tcp://$HOSTIP:$RCPORT > $flog 2>&1 &
 #printf "The logs from the HGCalProducer are in $flog file. \n"
 
-sleep 1
+sleep 2
 
 #######################################################################
 # AHCAL producer
@@ -118,6 +118,14 @@ sleep 1
 printf '\033[22;33m\t  caliceProducer-scintillator  \033[0m \n'
 xterm -sb -sl 1000000 -geom 160x10-480-900 -fn fixed -T "CALICE AHCAL" -e "./AHCALProducer.exe -n CaliceSc -r tcp://$TLUIP:$RCPORT && read || read" & 
 #./AHCALProducer.exe -n CaliceSc -r tcp://$TLUIP:$RCPORT 
+
+sleep 2
+
+######################################################################
+# wire chamber Producer
+###############
+printf '\033[22;33m\t delay wire chamber Producer \033[0m \n'
+xterm -sb -sl 1000 -geom 80x600-280-900 -fn fixed -T "Delay Wire Chamber Producer" -e './WireChamberProducer.exe -l DEBUG -r tcp://$HOSTIP:$RCPORT' &
 
 sleep 2
 

--- a/producers/cmshgcal/conf/AllInOneProducer.conf
+++ b/producers/cmshgcal/conf/AllInOneProducer.conf
@@ -80,3 +80,42 @@ AHCALBXID0Offset = 2123
 AHCALBXIDWidth = 160
 
 
+
+[Producer.DWCs]
+dataFilePrefix = "../data/dwc_run_"
+AcquisitionMode = 0
+
+
+baseAddress = 0x00AA0000
+model = 1
+triggerTimeSubtraction = 1
+triggerMatchMode = 1
+emptyEventEnable = 1
+edgeDetectionMode = 2
+timeResolution = 3
+maxHitsPerEvent = 9
+enabledChannels = 0xFFFF
+windowWidth = 0x40
+windowOffset = -10
+
+
+defaultTimestamp = -999
+
+N_channels = 16
+
+channel_0 = 1
+channel_1 = 1
+channel_2 = 1
+channel_3 = 1
+channel_4 = 1
+channel_5 = 1
+channel_6 = 1
+channel_7 = 1
+channel_8 = 1
+channel_9 = 1
+channel_10 = 1
+channel_11 = 1
+channel_12 = 1
+channel_13 = 1
+channel_14 = 1
+channel_15 = 1

--- a/producers/cmshgcal/conf/AllInOneProducer.conf
+++ b/producers/cmshgcal/conf/AllInOneProducer.conf
@@ -119,3 +119,24 @@ channel_12 = 1
 channel_13 = 1
 channel_14 = 1
 channel_15 = 1
+
+
+dwc1_left_channel = 0
+dwc1_right_channel = 1
+dwc1_down_channel = 2
+dwc1_up_channel = 3
+dwc2_left_channel = 4
+dwc2_right_channel = 5
+dwc2_down_channel = 6
+dwc2_up_channel = 7
+dwc3_left_channel = 8
+dwc3_right_channel = 9
+dwc3_down_channel = 10
+dwc3_up_channel = 11
+dwc4_left_channel = 12
+dwc4_right_channel = 13
+dwc4_down_channel = 14
+dwc4_up_channel = 15
+
+slope_x = 0.2
+slope_y = 0.2

--- a/producers/cmshgcal/onlinemon/include/WireChamberHistos.hh
+++ b/producers/cmshgcal/onlinemon/include/WireChamberHistos.hh
@@ -3,7 +3,7 @@
 #ifndef WIRECHAMBERHISTOS_HH_
 #define WIRECHAMBERHISTOS_HH_
 
-#include <TH2I.h>
+#include <TH2F.h>
 #include <TH2Poly.h>
 #include <TFile.h>
 
@@ -23,7 +23,7 @@ protected:
   int _maxY;
   bool _wait;
 
-  TH2I *_XYmap;
+  TH2F *_XYmap;
   
 public:
   WireChamberHistos(eudaq::StandardPlane p, RootMonitor *mon);
@@ -34,7 +34,7 @@ public:
   void Calculate(const int currentEventNum);
   void Write();
 
-  TH2I *getXYmapHisto() { return _XYmap; }
+  TH2F *getXYmapHisto() { return _XYmap; }
 
   
   void setRootMonitor(RootMonitor *mon) { _mon = mon; }

--- a/producers/cmshgcal/onlinemon/include/WireChamberHistos.hh
+++ b/producers/cmshgcal/onlinemon/include/WireChamberHistos.hh
@@ -4,6 +4,8 @@
 #define WIRECHAMBERHISTOS_HH_
 
 #include <TH2F.h>
+#include <TH2I.h>
+#include <TH1F.h>
 #include <TH2Poly.h>
 #include <TFile.h>
 
@@ -23,6 +25,11 @@ protected:
   int _maxY;
   bool _wait;
 
+  TH2I *_goodX;
+  TH2I *_goodY;
+  TH1F *_recoX;
+  TH1F *_recoY;
+  TH1I *_goodAll;
   TH2F *_XYmap;
   
 public:
@@ -34,6 +41,11 @@ public:
   void Calculate(const int currentEventNum);
   void Write();
 
+  TH2I *getGoodXHisto() { return _goodX; }
+  TH2I *getGoodYHisto() { return _goodY; }
+  TH1I *getGoodAllHisto() { return _goodAll; }
+  TH1F *getRecoXHisto() { return _recoX; }
+  TH1F *getRecoYHisto() { return _recoY; }
   TH2F *getXYmapHisto() { return _XYmap; }
 
   

--- a/producers/cmshgcal/onlinemon/src/WireChamberCollection.cc
+++ b/producers/cmshgcal/onlinemon/src/WireChamberCollection.cc
@@ -125,7 +125,7 @@ void WireChamberCollection::registerPlane(const eudaq::StandardPlane &p) {
     char tree[1024], folder[1024];
     sprintf(folder, "%s", p.Sensor().c_str());
     
-    sprintf(tree, "%s/Chamber %i/XY map", p.Sensor().c_str(), p.ID());
+    sprintf(tree, "%s/Chamber %i/XY map", p.Sensor().c_str(), p.ID());      //Todo: Register here when more is added
     _mon->getOnlineMon()->registerTreeItem(tree);
     _mon->getOnlineMon()->registerHisto(tree, getWireChamberHistos(p.Sensor(), p.ID())->getXYmapHisto(), "COLZ2", 0);
     _mon->getOnlineMon()->addTreeItemSummary(folder, tree);    

--- a/producers/cmshgcal/onlinemon/src/WireChamberCollection.cc
+++ b/producers/cmshgcal/onlinemon/src/WireChamberCollection.cc
@@ -125,10 +125,43 @@ void WireChamberCollection::registerPlane(const eudaq::StandardPlane &p) {
     char tree[1024], folder[1024];
     sprintf(folder, "%s", p.Sensor().c_str());
     
-    sprintf(tree, "%s/Chamber %i/XY map", p.Sensor().c_str(), p.ID());      //Todo: Register here when more is added
+    sprintf(tree, "%s/Chamber %i/good X", p.Sensor().c_str(), p.ID());      //Todo: Register here when more is added
+    _mon->getOnlineMon()->registerTreeItem(tree);
+    _mon->getOnlineMon()->registerHisto(tree, getWireChamberHistos(p.Sensor(), p.ID())->getGoodXHisto(), "COLZ2", 0);
+    _mon->getOnlineMon()->addTreeItemSummary(folder, tree); 
+
+
+    sprintf(tree, "%s/Chamber %i/good Y", p.Sensor().c_str(), p.ID());      //Todo: Register here when more is added
+    _mon->getOnlineMon()->registerTreeItem(tree);
+    _mon->getOnlineMon()->registerHisto(tree, getWireChamberHistos(p.Sensor(), p.ID())->getGoodYHisto(), "COLZ2", 0);
+    _mon->getOnlineMon()->addTreeItemSummary(folder, tree); 
+
+
+    sprintf(tree, "%s/Chamber %i/Valid Measurement", p.Sensor().c_str(), p.ID());      //Todo: Register here when more is added
+    _mon->getOnlineMon()->registerTreeItem(tree);
+    _mon->getOnlineMon()->registerHisto(tree, getWireChamberHistos(p.Sensor(), p.ID())->getGoodAllHisto(), "", 0);
+    _mon->getOnlineMon()->addTreeItemSummary(folder, tree); 
+
+
+    sprintf(tree, "%s/Chamber %i/reco X", p.Sensor().c_str(), p.ID());      //Todo: Register here when more is added
+    _mon->getOnlineMon()->registerTreeItem(tree);
+    _mon->getOnlineMon()->registerHisto(tree, getWireChamberHistos(p.Sensor(), p.ID())->getRecoXHisto(), "", 0);
+    _mon->getOnlineMon()->addTreeItemSummary(folder, tree); 
+
+
+    sprintf(tree, "%s/Chamber %i/reco Y", p.Sensor().c_str(), p.ID());      //Todo: Register here when more is added
+    _mon->getOnlineMon()->registerTreeItem(tree);
+    _mon->getOnlineMon()->registerHisto(tree, getWireChamberHistos(p.Sensor(), p.ID())->getRecoYHisto(), "", 0);
+    _mon->getOnlineMon()->addTreeItemSummary(folder, tree); 
+
+    
+    sprintf(tree, "%s/Chamber %i/reco XY", p.Sensor().c_str(), p.ID());      //Todo: Register here when more is added
     _mon->getOnlineMon()->registerTreeItem(tree);
     _mon->getOnlineMon()->registerHisto(tree, getWireChamberHistos(p.Sensor(), p.ID())->getXYmapHisto(), "COLZ2", 0);
     _mon->getOnlineMon()->addTreeItemSummary(folder, tree);    
+    
+    
+    
     
     ///
     

--- a/producers/cmshgcal/onlinemon/src/WireChamberHistos.cc
+++ b/producers/cmshgcal/onlinemon/src/WireChamberHistos.cc
@@ -9,9 +9,8 @@
 
 WireChamberHistos::WireChamberHistos(eudaq::StandardPlane p, RootMonitor *mon)
   :_sensor(p.Sensor()), _id(p.ID()), _maxX(p.XSize()),  _maxY(p.YSize()), _wait(false),
-  _XYmap(NULL){
+  _XYmap(NULL), _goodX(NULL), _goodY(NULL), _goodAll(NULL), _recoX(NULL), _recoY(NULL){
     
-
   char out[1024], out2[1024];
 
   _mon = mon;
@@ -20,6 +19,31 @@ WireChamberHistos::WireChamberHistos(eudaq::StandardPlane p, RootMonitor *mon)
   // std::endl;
 
   if (_maxX != -1 && _maxY != -1) {
+
+    sprintf(out, "%s %i good X", _sensor.c_str(), _id);
+    sprintf(out2, "h_goodX_%s_%i", _sensor.c_str(), _id);
+    _goodX = new TH2I(out2, out, 2, 0, 2, 2, 0, 2);
+    SetHistoAxisLabels(_goodX, "measured x_{left} ?", "measured x_{right} ?");
+
+    sprintf(out, "%s %i good Y", _sensor.c_str(), _id);
+    sprintf(out2, "h_goodY_%s_%i", _sensor.c_str(), _id);
+    _goodY = new TH2I(out2, out, 2, 0, 2, 2, 0, 2);
+    SetHistoAxisLabels(_goodY, "measured y_{up} ?", "measured y_{down} ?");
+
+    sprintf(out, "%s %i good All", _sensor.c_str(), _id);
+    sprintf(out2, "h_goodAll_%s_%i", _sensor.c_str(), _id);
+    _goodAll = new TH1I(out2, out, 2, 0, 2);
+    SetHistoAxisLabels(_goodAll, "measurement ok ?", "N");
+
+    sprintf(out, "%s %i reco X", _sensor.c_str(), _id);
+    sprintf(out2, "h_recoX_%s_%i", _sensor.c_str(), _id);
+    _recoX = new TH1F(out2, out, 100, -50., 50.);
+    SetHistoAxisLabels(_recoX, "X (mm)", "N");
+
+    sprintf(out, "%s %i reco Y", _sensor.c_str(), _id);
+    sprintf(out2, "h_recoY_%s_%i", _sensor.c_str(), _id);
+    _recoY = new TH1F(out2, out, 100, -50., 50.);
+    SetHistoAxisLabels(_recoY, "Y (mm)", "N");
 
     sprintf(out, "%s %i XY map", _sensor.c_str(), _id);
     sprintf(out2, "h_XYmap_%s_%i", _sensor.c_str(), _id);
@@ -68,9 +92,9 @@ void WireChamberHistos::Fill(const eudaq::StandardPlane &plane) {
   float yd = plane.GetPixel(3);
 
   int good_xl = xl >= 0 ? 1 : 0;
-  int good_xr = xl >= 0 ? 1 : 0;
-  int good_yu = xl >= 0 ? 1 : 0;
-  int good_yd = xl >= 0 ? 1 : 0;
+  int good_xr = xr >= 0 ? 1 : 0;
+  int good_yu = yu >= 0 ? 1 : 0;
+  int good_yd = yd >= 0 ? 1 : 0;
   int good_x = (good_xl+good_xr) == 2 ? 1: 0;
   int good_y = (good_yu+good_yd) == 2 ? 1: 0;
   int good_all = (good_x+good_y) == 2 ? 1: 0;
@@ -78,12 +102,25 @@ void WireChamberHistos::Fill(const eudaq::StandardPlane &plane) {
   float x = (xr-xl)*0.2;
   float y = (yd-yu)*0.2;
   
+  _goodX->Fill(good_xl, good_xr);
+  _goodY->Fill(good_yu, good_yd);
+  _goodAll->Fill(good_all);
+
+  if (good_x) {
+    std::cout<<"In Filling of 1D-Hists: x="<<x<<std::endl;
+    _recoX->Fill(x);
+  }
+
+  if (good_y) {
+    std::cout<<"In Filling of 1D-Hists: y="<<y<<std::endl;
+    _recoY->Fill(y);
+  }
 
   if (good_all) {
     std::cout<<"In Filling of 2D-Hists: x="<<x<<" y="<<y<<std::endl;
     _XYmap->Fill(x,y);
   }
-  
+
 }
 
 void WireChamberHistos::Reset() {

--- a/producers/cmshgcal/onlinemon/src/WireChamberHistos.cc
+++ b/producers/cmshgcal/onlinemon/src/WireChamberHistos.cc
@@ -62,12 +62,28 @@ int WireChamberHistos::zero_plane_array() {
 void WireChamberHistos::Fill(const eudaq::StandardPlane &plane) {
   // std::cout<< "FILL with a plane." << std::endl;
 
-  const float x = plane.GetPixel(0);
-  const float y = plane.GetPixel(1);
+  float xl = plane.GetPixel(0);
+  float xr = plane.GetPixel(1);
+  float yu = plane.GetPixel(2);
+  float yd = plane.GetPixel(3);
 
-  std::cout<<"In Filling of Hists: x="<<x<<" y="<<y<<std::endl;
+  int good_xl = xl >= 0 ? 1 : 0;
+  int good_xr = xl >= 0 ? 1 : 0;
+  int good_yu = xl >= 0 ? 1 : 0;
+  int good_yd = xl >= 0 ? 1 : 0;
+  int good_x = (good_xl+good_xr) == 2 ? 1: 0;
+  int good_y = (good_yu+good_yd) == 2 ? 1: 0;
+  int good_all = (good_x+good_y) == 2 ? 1: 0;
   
-  _XYmap->Fill(x,y);
+  float x = (xr-xl)*0.2;
+  float y = (yd-yu)*0.2;
+  
+
+  if (good_all) {
+    std::cout<<"In Filling of 2D-Hists: x="<<x<<" y="<<y<<std::endl;
+    _XYmap->Fill(x,y);
+  }
+  
 }
 
 void WireChamberHistos::Reset() {

--- a/producers/cmshgcal/onlinemon/src/WireChamberHistos.cc
+++ b/producers/cmshgcal/onlinemon/src/WireChamberHistos.cc
@@ -4,7 +4,6 @@
 #include "WireChamberHistos.hh"
 #include "OnlineMon.hh"
 #include "TCanvas.h"
-#include "TGraph.h"
 #include <cstdlib>
 #include <sstream>
 
@@ -24,8 +23,8 @@ WireChamberHistos::WireChamberHistos(eudaq::StandardPlane p, RootMonitor *mon)
 
     sprintf(out, "%s %i XY map", _sensor.c_str(), _id);
     sprintf(out2, "h_XYmap_%s_%i", _sensor.c_str(), _id);
-    _XYmap = new TH2I(out2, out, 50, -4, 4, 50, -4, 4);
-    SetHistoAxisLabels(_XYmap, "X (cm)", "Y (cm)");
+    _XYmap = new TH2F(out2, out, 100, -50., 50., 100, -50., 50.);
+    SetHistoAxisLabels(_XYmap, "X (mm)", "Y (mm)");
     
 
     // make a plane array for calculating e..g hotpixels and occupancy

--- a/producers/cmshgcal/onlinemon/src/WireChamberHistos.cc
+++ b/producers/cmshgcal/onlinemon/src/WireChamberHistos.cc
@@ -99,8 +99,8 @@ void WireChamberHistos::Fill(const eudaq::StandardPlane &plane) {
   int good_y = (good_yu+good_yd) == 2 ? 1: 0;
   int good_all = (good_x+good_y) == 2 ? 1: 0;
   
-  float x = (xr-xl)*0.2;
-  float y = (yd-yu)*0.2;
+  float x = (xr-xl)/40*0.2; //one time unit of the tdc corresponds to 25ps, 1. conversion into nm, 
+  float y = (yd-yu)/40*0.2; //2. conversion from nm to mm via the default calibration factor from the DWC manual
   
   _goodX->Fill(good_xl, good_xr);
   _goodY->Fill(good_yu, good_yd);

--- a/producers/cmshgcal_dwc/conf/hgcaldwc.conf
+++ b/producers/cmshgcal_dwc/conf/hgcaldwc.conf
@@ -37,6 +37,25 @@ channel_13 = 1
 channel_14 = 1
 channel_15 = 1
 
+dwc1_left_channel = 0
+dwc1_right_channel = 1
+dwc1_down_channel = 2
+dwc1_up_channel = 3
+dwc2_left_channel = 4
+dwc2_right_channel = 5
+dwc2_down_channel = 6
+dwc2_up_channel = 7
+dwc3_left_channel = 8
+dwc3_right_channel = 9
+dwc3_down_channel = 10
+dwc3_up_channel = 11
+dwc4_left_channel = 12
+dwc4_right_channel = 13
+dwc4_down_channel = 14
+dwc4_up_channel = 15
+
+slope_x = 0.2
+slope_y = 0.2
 
 [DataCollector]
 FilePattern = "../data/run$6R$X"

--- a/producers/cmshgcal_dwc/include/CAEN_v1290.h
+++ b/producers/cmshgcal_dwc/include/CAEN_v1290.h
@@ -4,7 +4,8 @@
 #include <string>
 #include <vector> 
 #include <iostream>
-#include <random>
+#include <stdlib.h>
+
 
 #include "eudaq/Utils.hh"
 
@@ -145,7 +146,8 @@ public:
 
   } CAEN_V1290_Config_t;
 
-  CAEN_V1290(): handle_(-1) { type_="CAEN_V1290"; id_=0; _isConfigured=false;};
+  CAEN_V1290(): handle_(-1) { type_="CAEN_V1290"; id_=0; _isConfigured=false; srand(0);
+  };
 
   inline unsigned int GetId(){return id_;};
   inline void SetId(unsigned int id){id_=id;};
@@ -184,6 +186,7 @@ private:
   uint32_t handle_;
   CAEN_V1290_Config_t configuration_;
   uint32_t channels_;
+
 
 protected:
   unsigned int id_;

--- a/producers/cmshgcal_dwc/include/CAEN_v1290.h
+++ b/producers/cmshgcal_dwc/include/CAEN_v1290.h
@@ -154,7 +154,7 @@ public:
   // --- Configurable  
   
 
-  virtual int Init();
+  virtual bool Init();
   virtual int SetupModule();
   virtual int Clear();
   virtual int ClearBusy() {return 0;};

--- a/producers/cmshgcal_dwc/src/CAEN_v1290.cc
+++ b/producers/cmshgcal_dwc/src/CAEN_v1290.cc
@@ -558,6 +558,8 @@ void CAEN_V1290::generatePseudoData(std::vector<WORD> &data) {
   
   //generate the channel information
   for (unsigned int channel=0; channel<16; channel++) {
+    if (rand()%100 < 10) continue;  //ten percent change of no hit detection 
+
     unsigned int readout;
     readout=(unsigned int)(rand()%250) + 75;
 

--- a/producers/cmshgcal_dwc/src/CAEN_v1290.cc
+++ b/producers/cmshgcal_dwc/src/CAEN_v1290.cc
@@ -3,13 +3,13 @@
 
 //#define CAENV1290_DEBUG 
 
-int CAEN_V1290::Init() {
+bool CAEN_V1290::Init() {
   int status=0;
   std::cout<< "[CAEN_V1290]::[INFO]::++++++ CAEN V1290 INIT ++++++"<<std::endl;
   
   if (handle_<0) {
     std::cout<<"Handle is negative --> Init has failed."<<std::endl;
-    return ERR_CONF_NOT_FOUND;
+    return false;
   }
 
   char* software_version = new char[100];
@@ -27,9 +27,9 @@ int CAEN_V1290::Init() {
   
   if (status) {
     std::cout << "[CAEN_VX2718]::[ERROR]::Cannot open VX2718 board." << std::endl;
-    return ERR_OPEN;
+    return false;
   }  
-  return 0;
+  return true;
 }
 
 int CAEN_V1290::SetupModule() {

--- a/producers/cmshgcal_dwc/src/CAEN_v1290.cc
+++ b/producers/cmshgcal_dwc/src/CAEN_v1290.cc
@@ -237,7 +237,6 @@ int CAEN_V1290::Config(CAEN_V1290::CAEN_V1290_Config_t &_config) {
 int CAEN_V1290::Read(std::vector<WORD> &v) {
   int status = 0; 
 
-  v.clear();
   if (handle_<0) {
     return ERR_CONF_NOT_FOUND;
   }
@@ -549,27 +548,7 @@ int CAEN_V1290::SoftwareTrigger() {
 
 
 void CAEN_V1290::generatePseudoData(std::vector<WORD> &data) {
-  std::default_random_engine generator;
-  
-  std::vector< std::normal_distribution<double> > distrs;
-  distrs.push_back(std::normal_distribution<double>(600., 10.));
-  distrs.push_back(std::normal_distribution<double>(400., 10.));
-  distrs.push_back(std::normal_distribution<double>(650., 10.));
-  distrs.push_back(std::normal_distribution<double>(390., 10.));
-  distrs.push_back(std::normal_distribution<double>(610., 10.));
-  distrs.push_back(std::normal_distribution<double>(410., 10.));
-  distrs.push_back(std::normal_distribution<double>(660., 10.));
-  distrs.push_back(std::normal_distribution<double>(400., 10.));
-  distrs.push_back(std::normal_distribution<double>(600., 10.));
-  distrs.push_back(std::normal_distribution<double>(400., 10.));
-  distrs.push_back(std::normal_distribution<double>(650., 10.));
-  distrs.push_back(std::normal_distribution<double>(390., 10.));
-  distrs.push_back(std::normal_distribution<double>(610., 10.));
-  distrs.push_back(std::normal_distribution<double>(410., 10.));
-  distrs.push_back(std::normal_distribution<double>(660., 10.));
-  distrs.push_back(std::normal_distribution<double>(400., 10.));
 
-  
   WORD bitStream = 0;
 
   //first the BOE
@@ -580,8 +559,7 @@ void CAEN_V1290::generatePseudoData(std::vector<WORD> &data) {
   //generate the channel information
   for (unsigned int channel=0; channel<16; channel++) {
     unsigned int readout;
-    readout=distrs[channel](generator);
-    
+    readout=(unsigned int)(rand()%250) + 75;
 
     for (int N=0; N<20; N++) {
       bitStream = 0;

--- a/producers/cmshgcal_dwc/src/Unpacker.cc
+++ b/producers/cmshgcal_dwc/src/Unpacker.cc
@@ -73,7 +73,7 @@ tdcData Unpacker::ConvertTDCData(std::vector<WORD> Words) {
   Unpack(Words);
   
   for (int ch=0; ch<N_channels; ch++) {
-    currentData.timeOfArrivals[ch] = -1;  //fill all 16 channels with dummy values  
+    currentData.timeOfArrivals[ch] = -1;  //fill all 16 channels with a value indicating that no hit has been registered
   } 
 
   for(std::map<unsigned int, std::vector<unsigned int> >::iterator channelTimeStamps = timeStamps.begin(); channelTimeStamps != timeStamps.end(); ++channelTimeStamps) {

--- a/producers/cmshgcal_dwc/src/WireChamberConverterPlugin.cc
+++ b/producers/cmshgcal_dwc/src/WireChamberConverterPlugin.cc
@@ -106,43 +106,6 @@ namespace eudaq {
 
         for (size_t i = 0; i<wcs.size(); i++) sev.AddPlane(wcs[i]);
 
-        /*
-        StandardPlane wc2(1, EVENT_TYPE, sensortype);
-        StandardPlane wc3(2, EVENT_TYPE, sensortype);
-        StandardPlane wc4(3, EVENT_TYPE, sensortype);
-       
-        wc1.SetSizeRaw(1, 2);
-        wc2.SetSizeRaw(1, 2);
-        wc3.SetSizeRaw(1, 2);
-        wc4.SetSizeRaw(1, 2);
-        // We store 4 numbers into these "planes":
-        // X1,Y1 for first WC, X2,Y2 for second WC  
-        wc1.SetPixel(0, 0, 0, x1);
-        wc1.SetPixel(1, 0, 1, y1);
-        
-        wc2.SetPixel(0, 0, 0, x2);
-        wc2.SetPixel(1, 0, 1, y2);
-
-        wc3.SetPixel(0, 0, 0, x3);
-        wc3.SetPixel(1, 0, 1, y3);
-
-        wc4.SetPixel(0, 0, 0, x4);
-        wc4.SetPixel(1, 0, 1, y4);
-        
-        // Set the trigger ID
-        wc1.SetTLUEvent(GetTriggerID(ev));
-        wc2.SetTLUEvent(GetTriggerID(ev));
-        wc3.SetTLUEvent(GetTriggerID(ev));
-        wc4.SetTLUEvent(GetTriggerID(ev));
-        
-        // Add the plane to the StandardEvent
-        sev.AddPlane(wc1);
-        sev.AddPlane(wc2);
-        sev.AddPlane(wc3);
-        sev.AddPlane(wc4);
-
-        */
-
       	eudaq::mSleep(10);
 	
       }

--- a/producers/cmshgcal_dwc/src/WireChamberConverterPlugin.cc
+++ b/producers/cmshgcal_dwc/src/WireChamberConverterPlugin.cc
@@ -75,40 +75,62 @@ namespace eudaq {
 
       for (unsigned blo=0; blo<nBlocks; blo++){
 
-	std::cout<<"Block = "<<blo<<"  Raw GetID = "<<rev->GetID(blo)<<std::endl;
+              
+        std::cout<<"Block = "<<blo<<"  Raw GetID = "<<rev->GetID(blo)<<std::endl;
 
-	const RawDataEvent::data_t & bl = rev->GetBlock(blo);
+        const RawDataEvent::data_t & bl = rev->GetBlock(blo);
 
-	std::cout<<"size of block: "<<bl.size()<<std::endl;
+        std::cout<<"size of block: "<<bl.size()<<std::endl;
 
-	float x1,x2,y1,y2;	
-	memcpy(&x1, &bl[0], sizeof(x1));
-	memcpy(&y1, &bl[4], sizeof(y1));
-	memcpy(&x2, &bl[8], sizeof(x2));
-	memcpy(&y2, &bl[12], sizeof(y2));
+        float x1,x2,y1,y2,x3,y3,x4,y4;  
+        memcpy(&x1, &bl[0], sizeof(x1));
+        memcpy(&y1, &bl[4], sizeof(y1));
+        memcpy(&x2, &bl[8], sizeof(x2));
+        memcpy(&y2, &bl[12], sizeof(y2));
+        memcpy(&x3, &bl[16], sizeof(x3));
+        memcpy(&y3, &bl[20], sizeof(y3));
+        memcpy(&x4, &bl[24], sizeof(x4));
+        memcpy(&y4, &bl[28], sizeof(y4));
 
-	std::cout<<"x1="<<x1<<" y1="<<y1<<"     x2="<<x2<<" y2="<<y2<<std::endl;
+        std::cout<<"x1="<<x1<<" y1="<<y1<<"     x2="<<x2<<" y2="<<y2;
+        std::cout<<" x3="<<x3<<" y3="<<y3<<"     x4="<<x4<<" y4="<<y4<<std::endl;
 
-	
-	StandardPlane wc0(0, EVENT_TYPE, sensortype);
-	StandardPlane wc1(1, EVENT_TYPE, sensortype);
-	wc0.SetSizeRaw(1, 2);
-	wc1.SetSizeRaw(1, 2);
-	// We store 4 numbers into these "planes":
-	// X1,Y1 for first WC, X2,Y2 for second WC	
-      	wc0.SetPixel(0, 0, 0, x1);
-	wc0.SetPixel(1, 0, 1, y1);
-      	wc1.SetPixel(0, 0, 0, x2);
-	wc1.SetPixel(1, 0, 1, y2);
-	
-	// Set the trigger ID
-	wc0.SetTLUEvent(GetTriggerID(ev));
-	wc1.SetTLUEvent(GetTriggerID(ev));
-	// Add the plane to the StandardEvent
-	sev.AddPlane(wc0);
-	sev.AddPlane(wc1);
-	
-	eudaq::mSleep(10);
+        
+        StandardPlane wc1(0, EVENT_TYPE, sensortype);
+        StandardPlane wc2(1, EVENT_TYPE, sensortype);
+        StandardPlane wc3(2, EVENT_TYPE, sensortype);
+        StandardPlane wc4(3, EVENT_TYPE, sensortype);
+        wc1.SetSizeRaw(1, 2);
+        wc2.SetSizeRaw(1, 2);
+        wc3.SetSizeRaw(1, 2);
+        wc4.SetSizeRaw(1, 2);
+        // We store 4 numbers into these "planes":
+        // X1,Y1 for first WC, X2,Y2 for second WC  
+        wc1.SetPixel(0, 0, 0, x1);
+        wc1.SetPixel(1, 0, 1, y1);
+        
+        wc2.SetPixel(0, 0, 0, x2);
+        wc2.SetPixel(1, 0, 1, y2);
+
+        wc3.SetPixel(0, 0, 0, x3);
+        wc3.SetPixel(1, 0, 1, y3);
+
+        wc4.SetPixel(0, 0, 0, x4);
+        wc4.SetPixel(1, 0, 1, y4);
+        
+        // Set the trigger ID
+        wc1.SetTLUEvent(GetTriggerID(ev));
+        wc2.SetTLUEvent(GetTriggerID(ev));
+        wc3.SetTLUEvent(GetTriggerID(ev));
+        wc4.SetTLUEvent(GetTriggerID(ev));
+        
+        // Add the plane to the StandardEvent
+        sev.AddPlane(wc1);
+        sev.AddPlane(wc2);
+        sev.AddPlane(wc3);
+        sev.AddPlane(wc4);
+
+      	eudaq::mSleep(10);
 	
       }
       

--- a/producers/cmshgcal_dwc/src/WireChamberProducer.cxx
+++ b/producers/cmshgcal_dwc/src/WireChamberProducer.cxx
@@ -104,9 +104,6 @@ class WireChamberProducer : public eudaq::Producer {
     dwc4_down_channel = config.Get("dwc4_down_channel", 14); 
     dwc4_up_channel = config.Get("dwc4_up_channel", 15);
       
-    slope_x = config.Get("slope_x", 0.2);
-    slope_y = config.Get("slope_y", 0.2);
-
 
     if (_mode == DWC_RUN) {
       if (!initialized) {  //the initialization is to be run just once
@@ -220,6 +217,8 @@ class WireChamberProducer : public eudaq::Producer {
         continue;
 
       m_ev++;
+     
+
       tdcData unpacked = tdc_unpacker->ConvertTDCData(dataStream);
 
       for (int channel=0; channel<N_channels; channel++) {
@@ -240,36 +239,36 @@ class WireChamberProducer : public eudaq::Producer {
  
       //ATTENTION !
       //possible source of segfault if the key, i.e. the assigned channel is not in between 0 and N_channels. N_channels and all the channel assignments originate from the configuration
-
       PosXY.clear();
-      //x-y of wire chamber 1
-      float X1 = slope_x * (dwc_timestamps[dwc1_left_channel] - dwc_timestamps[dwc1_right_channel]);
-      PosXY.push_back(X1);
-      float Y1 = slope_y * (dwc_timestamps[dwc1_down_channel] - dwc_timestamps[dwc1_up_channel]); 
-      PosXY.push_back(Y1);
+      PosXY.push_back(dwc_timestamps[dwc1_left_channel]);
+      PosXY.push_back(dwc_timestamps[dwc1_right_channel]);
+      PosXY.push_back(dwc_timestamps[dwc1_down_channel]);
+      PosXY.push_back(dwc_timestamps[dwc1_up_channel]);
       
       //x-y of wire chamber 2
-      float X2 = slope_x * (dwc_timestamps[dwc2_left_channel] - dwc_timestamps[dwc2_right_channel]);
-      PosXY.push_back(X2);
-      float Y2 = slope_y * (dwc_timestamps[dwc2_down_channel] - dwc_timestamps[dwc2_up_channel]); 
-      PosXY.push_back(Y2);
+      PosXY.push_back(dwc_timestamps[dwc2_left_channel]);
+      PosXY.push_back(dwc_timestamps[dwc2_right_channel]);
+      PosXY.push_back(dwc_timestamps[dwc2_down_channel]);
+      PosXY.push_back(dwc_timestamps[dwc2_up_channel]);
       
       //x-y of wire chamber 3
-      float X3 = slope_x * (dwc_timestamps[dwc3_left_channel] - dwc_timestamps[dwc3_right_channel]);
-      PosXY.push_back(X3);
-      float Y3 = slope_y * (dwc_timestamps[dwc3_down_channel] - dwc_timestamps[dwc3_up_channel]); 
-      PosXY.push_back(Y3);  
+      PosXY.push_back(dwc_timestamps[dwc3_left_channel]);
+      PosXY.push_back(dwc_timestamps[dwc3_right_channel]);
+      PosXY.push_back(dwc_timestamps[dwc3_down_channel]);
+      PosXY.push_back(dwc_timestamps[dwc3_up_channel]);  
 
       //x-y of wire chamber 4
-      float X4 = slope_x * (dwc_timestamps[dwc4_left_channel] - dwc_timestamps[dwc4_right_channel]);
-      PosXY.push_back(X4);
-      float Y4 = slope_y * (dwc_timestamps[dwc4_down_channel] - dwc_timestamps[dwc4_up_channel]); 
-      PosXY.push_back(Y4);
+      PosXY.push_back(dwc_timestamps[dwc4_left_channel]);
+      PosXY.push_back(dwc_timestamps[dwc4_right_channel]);
+      PosXY.push_back(dwc_timestamps[dwc4_down_channel]);
+      PosXY.push_back(dwc_timestamps[dwc4_up_channel]);
+
 
       //making an EUDAQ event
       eudaq::RawDataEvent ev(EVENT_TYPE,m_run,m_ev);
 
-      ev.AddBlock(0, PosXY);
+      ev.AddBlock(0, dataStream);
+      ev.AddBlock(1, PosXY);
 
       //Adding the event to the EUDAQ format
       SendEvent(ev);
@@ -306,7 +305,6 @@ class WireChamberProducer : public eudaq::Producer {
 
     std::vector<float> PosXY;
     //mapping and conversion parameters for the online monitoring
-    double slope_x, slope_y;
     size_t dwc1_left_channel, dwc1_right_channel, dwc1_down_channel, dwc1_up_channel, dwc2_left_channel, dwc2_right_channel, dwc2_down_channel, dwc2_up_channel, dwc3_left_channel, dwc3_right_channel, dwc3_down_channel, dwc3_up_channel, dwc4_left_channel, dwc4_right_channel, dwc4_down_channel, dwc4_up_channel;
 
 };

--- a/producers/cmshgcal_dwc/src/WireChamberProducer.cxx
+++ b/producers/cmshgcal_dwc/src/WireChamberProducer.cxx
@@ -88,8 +88,10 @@ class WireChamberProducer : public eudaq::Producer {
       if (!initialized) {  //the initialization is to be run just once
         initialized = tdc->Init();
       }
-      tdc->Config(_config);
-      tdc->SetupModule();
+      if (initialized) {
+        tdc->Config(_config);
+        tdc->SetupModule();
+      }
     }
 
     defaultTimestamp = config.Get("defaultTimestamp", -999);
@@ -168,6 +170,8 @@ class WireChamberProducer : public eudaq::Producer {
   }
 
 
+
+
   void ReadoutLoop() {
 
     while(!done) {
@@ -177,7 +181,7 @@ class WireChamberProducer : public eudaq::Producer {
       }
 
       if (stopping) continue;
-      if (_mode==DWC_RUN) {
+      if (_mode==DWC_RUN && initialized) {
         tdc->Read(dataStream);
       } else if (_mode==DWC_DEBUG) {
         eudaq::mSleep(1000);

--- a/producers/cmshgcal_dwc/src/WireChamberProducer.cxx
+++ b/producers/cmshgcal_dwc/src/WireChamberProducer.cxx
@@ -33,7 +33,7 @@ class WireChamberProducer : public eudaq::Producer {
   WireChamberProducer(const std::string & name, const std::string & runcontrol)
     : eudaq::Producer(name, runcontrol), m_run(0), m_ev(0), stopping(false), done(false), started(0) {
       tdc = new CAEN_V1290();
-      opticalLinkInitialized = false;
+      initialized = false;
       tdc_unpacker = NULL;
       outTree=NULL;
       _mode = DWC_DEBUG;
@@ -83,10 +83,10 @@ class WireChamberProducer : public eudaq::Producer {
       std::cout<<"TDC channel "<<channel<<" connected ? "<<channels_enabled[channel]<<std::endl;
     }
 
+
     if (_mode == DWC_RUN) {
-      if (!opticalLinkInitialized) {  //the initialization is to be run just once
-        tdc->Init();
-        opticalLinkInitialized = true;
+      if (!initialized) {  //the initialization is to be run just once
+        initialized = tdc->Init();
       }
       tdc->Config(_config);
       tdc->SetupModule();
@@ -229,7 +229,7 @@ class WireChamberProducer : public eudaq::Producer {
 
     unsigned m_run, m_ev;
     bool stopping, done, started;
-    bool opticalLinkInitialized;
+    bool initialized;
 
     std::string dataFilePrefix;
 

--- a/producers/cmshgcal_dwc/src/WireChamberProducer.cxx
+++ b/producers/cmshgcal_dwc/src/WireChamberProducer.cxx
@@ -106,8 +106,11 @@ class WireChamberProducer : public eudaq::Producer {
     m_ev = 0;
     EUDAQ_INFO("Start Run: "+param);
 
-    if (_mode==DWC_RUN)
+    if (_mode==DWC_RUN && initialized)
       tdc->BufferClear();
+    else if (!initialized)
+      EUDAQ_INFO("ATTENTION !!! Communication to the TDC has not been established");
+
 
     dwc_timestamps.clear();
     channels.clear();


### PR DESCRIPTION
- Conversion from timestamps to mm impact positions (assuming 25ps TDC resolution and 0.2mm/ns).
- Channel mapping to the DWC channels done in the wirechamberproducer (configurable).
- Reco X/Y histograms for up to four wire chambers added. Also, display of 'valid' measurements for each channel via TH2I (0: no measurement taken, 1: valid measurement).

Additonally:
- WireChamberProducer stores raw data streams from the TDCs as block 0 to the EUDAQ event object.
- Fixed bug, i.e. the segmentation fault when running the DAQ running mode on a shut-down optical link module.
