### PR TITLE
Modified configuration to reset Skirocs each time the configuration f…

### DIFF
--- a/producers/cmshgcal/conf/AllInOneProducer.conf
+++ b/producers/cmshgcal/conf/AllInOneProducer.conf
@@ -27,8 +27,37 @@ RPI_1_IP = '127.0.0.1'
 portTCP = '55511'
 portUDP = '55512'
 
+# Instead of IP addresses, we use aliases for SSH for clarity. The alias-to-IP-address correspondence is defined here: $HOME/.ssh/config
+piSynch_IP = "piS"
+piRDOUT1_IP = "pi1"
+piRDOUT2_IP = "pi2"
+piRDOUT3_IP = "pi3"
+piRDOUT4_IP = "pi4"
 
+# Mask for which RDOUT boards to configure, as a string of 1s and 0s. 1 = enable, 0 = disable; leftmost digit is assumed to correspond to the board with IP = piRDOUT1_IP. For example, "0010" enables configuring only piRDOUT3, "1100" configures piRDOUT1 and piRDOUT2, etc.
+RDOUTMask = "0010"
 
+# Hardcoded SKIROC configuration strings for individual RDOUT boards. The script is executed in the following format:
+# source targetDirPath_Skirocs/resetConfiguration_Skirocs_exe_fileName INDICES_STRING
+# where INDICES_STRING is the following:
+# skirocIndices_RDOUT1 = "1 3 2 4"
+# skirocIndices_RDOUT2 = "1 3 2 4"
+# skirocIndices_RDOUT3 = "1 3 2 4"
+# skirocIndices_RDOUT4 = "1 3 2 4"
+skirocIndices_RDOUT1 = " "
+skirocIndices_RDOUT2 = " "
+skirocIndices_RDOUT3 = "0 1 2 3 4"
+skirocIndices_RDOUT4 = " "
+
+sourceDirPath_Synch = "/home/daq/forConfiguration_EUDAQ/sourceDir_Synch"
+targetDirPath_Synch = "/home/pi/forConfiguration_EUDAQ/targetDir_Synch"
+resetConfiguration_Synch_exe_fileName = "resetConfiguration_Synch.sh"
+sourceDirPath_Readout = "/home/daq/forConfiguration_EUDAQ/sourceDir_Readout"
+targetDirPath_Readout = "/home/pi/forConfiguration_EUDAQ/targetDir_Readout"
+resetConfiguration_Readout_exe_fileName = "resetConfiguration_Readout.sh"
+sourceDirPath_Skirocs = "/home/daq/forConfiguration_EUDAQ/sourceDir_Skirocs"
+targetDirPath_Skirocs = "/home/pi/forConfiguration_EUDAQ/targetDir_Skirocs"
+resetConfiguration_Skirocs_exe_fileName = "resetConfiguration_Skirocs.sh"
 
 [Producer.CaliceSc]
 #FileLEDsettings ="F:\\LEDEUDAQ\\LED1.ini"

--- a/producers/cmshgcal/conf/RpiProducer.conf
+++ b/producers/cmshgcal/conf/RpiProducer.conf
@@ -26,3 +26,35 @@ RPI_1_IP = '127.0.0.1'
 # These should not be changed:
 portTCP = '55511'
 portUDP = '55512'
+
+# Instead of IP addresses, we use aliases for SSH for clarity. The alias-to-IP-address correspondence is defined here: $HOME/.ssh/config
+piSynch_IP = "piS"
+piRDOUT1_IP = "pi1"
+piRDOUT2_IP = "pi2"
+piRDOUT3_IP = "pi3"
+piRDOUT4_IP = "pi4"
+
+# Mask for which RDOUT boards to configure, as a string of 1s and 0s. 1 = enable, 0 = disable; leftmost digit is assumed to correspond to the board with IP = piRDOUT1_IP. For example, "0010" enables configuring only piRDOUT3, "1100" configures piRDOUT1 and piRDOUT2, etc.
+RDOUTMask = "0010"
+
+# Hardcoded SKIROC configuration strings for individual RDOUT boards. The script is executed in the following format:
+# source targetDirPath_Skirocs/resetConfiguration_Skirocs_exe_fileName INDICES_STRING
+# where INDICES_STRING is the following:
+# skirocIndices_RDOUT1 = "1 3 2 4"
+# skirocIndices_RDOUT2 = "1 3 2 4"
+# skirocIndices_RDOUT3 = "1 3 2 4"
+# skirocIndices_RDOUT4 = "1 3 2 4"
+skirocIndices_RDOUT1 = " "
+skirocIndices_RDOUT2 = " "
+skirocIndices_RDOUT3 = "0 1 2 3 4"
+skirocIndices_RDOUT4 = " "
+
+sourceDirPath_Synch = "/home/daq/forConfiguration_EUDAQ/sourceDir_Synch"
+targetDirPath_Synch = "/home/pi/forConfiguration_EUDAQ/targetDir_Synch"
+resetConfiguration_Synch_exe_fileName = "resetConfiguration_Synch.sh"
+sourceDirPath_Readout = "/home/daq/forConfiguration_EUDAQ/sourceDir_Readout"
+targetDirPath_Readout = "/home/pi/forConfiguration_EUDAQ/targetDir_Readout"
+resetConfiguration_Readout_exe_fileName = "resetConfiguration_Readout.sh"
+sourceDirPath_Skirocs = "/home/daq/forConfiguration_EUDAQ/sourceDir_Skirocs"
+targetDirPath_Skirocs = "/home/pi/forConfiguration_EUDAQ/targetDir_Skirocs"
+resetConfiguration_Skirocs_exe_fileName = "resetConfiguration_Skirocs.sh"


### PR DESCRIPTION
…ile is loaded. Eventually we want to move this to the beginning of each run. Also added commented-out sections to reset ORMs on the Synch board and RDOUT board each time the configuration is loaded. Modified configuration files accordingly.

This has been tested online on an eudaq installation on svhgcal01 in the folder /home/daq/conf-eudaq-tanmay-july .