### PR TITLE
Pass TDC error streams to the producer to keep incrementing event numbers

### DIFF
--- a/producers/cmshgcal/conf/AllInOneProducer.conf
+++ b/producers/cmshgcal/conf/AllInOneProducer.conf
@@ -112,7 +112,7 @@ AHCALBXIDWidth = 160
 
 [Producer.DWCs]
 dataFilePrefix = "../data/dwc_run_"
-AcquisitionMode = 0
+AcquisitionMode = 1
 
 
 baseAddress = 0x00AA0000
@@ -124,8 +124,8 @@ edgeDetectionMode = 2
 timeResolution = 3
 maxHitsPerEvent = 9
 enabledChannels = 0xFFFF
-windowWidth = 0x40
-windowOffset = -10
+windowWidth = 0x400
+windowOffset = -100
 
 
 defaultTimestamp = -999
@@ -158,14 +158,14 @@ dwc2_left_channel = 4
 dwc2_right_channel = 5
 dwc2_down_channel = 6
 dwc2_up_channel = 7
-dwc3_left_channel = 8
-dwc3_right_channel = 9
-dwc3_down_channel = 10
-dwc3_up_channel = 11
-dwc4_left_channel = 12
-dwc4_right_channel = 13
-dwc4_down_channel = 14
-dwc4_up_channel = 15
+dwc3_left_channel = 15
+dwc3_right_channel = 14
+dwc3_down_channel = 13
+dwc3_up_channel = 12
+dwc4_left_channel = 11    
+dwc4_right_channel = 10
+dwc4_down_channel = 9
+dwc4_up_channel = 8
 
 slope_x = 0.2
 slope_y = 0.2

--- a/producers/cmshgcal_dwc/src/CAEN_v1290.cc
+++ b/producers/cmshgcal_dwc/src/CAEN_v1290.cc
@@ -261,11 +261,14 @@ int CAEN_V1290::Read(std::vector<WORD> &v) {
   }
 
   if (v1290_rdy==0) {
+    std::cout << "[CAEN_V1290]::[ERROR]::V1290 board not ready" << status << std::endl;   
+    v.push_back( (0x4 << 28) | (1 & 0x7FFF ));
     return ERR_READ;
   }
 
   if (status || v1290_error!=0) {
     std::cout << "[CAEN_V1290]::[ERROR]::Cannot get a valid data from V1290 board " << status << std::endl;   
+    v.push_back( (0x4 << 28) | (2 & 0x7FFF ));
     return ERR_READ;
   }  
 
@@ -283,6 +286,7 @@ int CAEN_V1290::Read(std::vector<WORD> &v) {
 
 
   if ( ! (data & 0x40000000) || status ) {
+    v.push_back( (0x4 << 28) | (3 & 0x7FFF ));
     std::cout << "[CAEN_V1290]::[ERROR]::First word not a Global header" << std::endl; 
     return ERR_READ;
   }

--- a/producers/cmshgcal_dwc/src/CAEN_v1290.cc
+++ b/producers/cmshgcal_dwc/src/CAEN_v1290.cc
@@ -238,6 +238,8 @@ int CAEN_V1290::Read(std::vector<WORD> &v) {
   int status = 0; 
 
   if (handle_<0) {
+    v.push_back( (0x4 << 28) | (0 & 0x7FFF ));
+    std::cout << "[CAEN_V1290]::[ERROR]::V1290 board handle not found" << status << std::endl; 
     return ERR_CONF_NOT_FOUND;
   }
 
@@ -339,6 +341,7 @@ int CAEN_V1290::Read(std::vector<WORD> &v) {
     } else if (wordType == CAEN_V1290_TDCERROR ) {
       std::cout << "[CAEN_V1290]::[ERROR]::TDC ERROR!" << std::endl; 
       v.clear();
+      v.push_back( (0x4 << 28) | (4 & 0x7FFF ));
       return ERR_READ;
     } else if (wordType == CAEN_V1290_TDCMEASURE ) {
       v.push_back(data);
@@ -353,6 +356,7 @@ int CAEN_V1290::Read(std::vector<WORD> &v) {
     } else {
       std::cout << "[CAEN_V1290]::[ERROR]::UNKNOWN WORD TYPE!" << std::endl; 
       v.clear();
+      v.push_back( (0x4 << 28) | (5 & 0x7FFF ));
       return ERR_READ;
     }
   }
@@ -360,6 +364,7 @@ int CAEN_V1290::Read(std::vector<WORD> &v) {
   if (status) {
     std::cout << "[CAEN_V1290]::[ERROR]::READ ERROR!" << std::endl; 
     v.clear();
+    v.push_back( (0x4 << 28) | (6 & 0x7FFF ));
     return ERR_READ;
   }
 

--- a/producers/cmshgcal_dwc/src/CAEN_v1290.cc
+++ b/producers/cmshgcal_dwc/src/CAEN_v1290.cc
@@ -264,7 +264,7 @@ int CAEN_V1290::Read(std::vector<WORD> &v) {
 
   if (v1290_rdy==0) {
     std::cout << "[CAEN_V1290]::[ERROR]::V1290 board not ready" << status << std::endl;   
-    v.push_back( (0x4 << 28) | (1 & 0x7FFF ));
+    //v.push_back( (0x4 << 28) | (1 & 0x7FFF ));
     return ERR_READ;
   }
 


### PR DESCRIPTION
1. This is crucial to guarantee synchronisation of events with the trigger. If the errors are not passed to the producer, the Readout loop is continued and no event is generated in the DAQ.

2. Configuration file is adjusted with the most-recent DWC-TDC channel mapping.