### PR TITLE
Adding more hexaboards for readout board 3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ PROJECT( EUDAQ )
 # project version
 SET( ${PROJECT_NAME}_VERSION_MAJOR 1 )
 SET( ${PROJECT_NAME}_VERSION_MINOR 6 )
-SET( ${PROJECT_NAME}_VERSION_PATCH 6 )
+SET( ${PROJECT_NAME}_VERSION_PATCH 8 )
 
 # some macros are redefined to keep compatability with CMake 2.6
 include(${PROJECT_SOURCE_DIR}/cmake/CMakeCompatibility.cmake)

--- a/producers/cmshgcal/onlinemon/src/AhcalHistos.cc
+++ b/producers/cmshgcal/onlinemon/src/AhcalHistos.cc
@@ -49,10 +49,11 @@ AhcalHistos::AhcalHistos(eudaq::StandardPlane p, RootMonitor *mon)
 
     sprintf(out, "%s %i Number of Hits", _sensor.c_str(), _id);
     sprintf(out2, "h_raw_nHits_%s_%i", _sensor.c_str(), _id);
-    _nHits = new TH1I(out2, out, 20, 0, 20);
+    _nHits = new TH1I(out2, out, 50, 0, 50);
     SetHistoAxisLabelx(_nHits, "Number of Hits above ZS");
     //_nHits->SetStats(1);
 
+    /* Not used
     sprintf(out, "%s %i Number of Invalid Hits", _sensor.c_str(), _id);
     sprintf(out2, "h_nbadHits_%s_%i", _sensor.c_str(), _id);
     _nbadHits = new TH1I(out2, out, 50, 0, 50);
@@ -62,7 +63,7 @@ AhcalHistos::AhcalHistos(eudaq::StandardPlane p, RootMonitor *mon)
     sprintf(out2, "h_nhotpixels_%s_%i", _sensor.c_str(), _id);
     _nHotPixels = new TH1I(out2, out, 50, 0, 50);
     SetHistoAxisLabelx(_nHotPixels, "n_{HotPixels}");
-
+    */
 
     // make a plane array for calculating e..g hotpixels and occupancy
 
@@ -99,11 +100,15 @@ int AhcalHistos::zero_plane_array() {
 void AhcalHistos::Fill(const eudaq::StandardPlane &plane) {
   // std::cout<< "FILL with a plane." << std::endl;
 
-  if (_nHits != NULL)
-    _nHits->Fill(plane.HitPixels());
-  if ((_nbadHits != NULL)) {
-    _nbadHits->Fill(0);
+  if (_nHits != NULL) {
+    if (plane.HitPixels() >= 50)
+      _nHits->Fill(49); // overflow
+    else
+      _nHits->Fill(plane.HitPixels());
   }
+  //if ((_nbadHits != NULL)) {
+  //_nbadHits->Fill(0);
+  //}
 
 
   for (unsigned int pix = 0; pix < plane.HitPixels(); pix++)

--- a/producers/cmshgcal/onlinemon/src/HexagonHistos.cc
+++ b/producers/cmshgcal/onlinemon/src/HexagonHistos.cc
@@ -226,6 +226,7 @@ void HexagonHistos::Fill(const eudaq::StandardPlane &plane) {
       const int pixel_y = plane.GetY(pix);
       const int ch  = _ski_to_ch_map.find(make_pair(pixel_x,pixel_y))->second;
 
+      // ----- Maskig noisy channels ----
       // These are noisy pixels in every hexaboard. Let's just mask them from DQM:
       if (pixel_x==3 && (pixel_y==32 || pixel_y==48))
 	continue;
@@ -236,7 +237,17 @@ void HexagonHistos::Fill(const eudaq::StandardPlane &plane) {
 	     plane.Sensor()=="HexaBoard-RDB3" && plane.ID()==1 ) &&
 	   ( pixel_x==0 && pixel_y==58 ) )
 	continue;
-      
+
+      if ( plane.Sensor()=="HexaBoard-RDB3" && plane.ID()==0 &&
+	   pixel_x==1 && pixel_y==4 )
+	continue;
+
+      if ( plane.Sensor()=="HexaBoard-RDB3" && plane.ID()==2 &&
+	   pixel_x==0 && pixel_y==22 )
+	continue;
+
+      // -------- end masking -------------
+
       //std::cout<<" We are getting a pixel with pix="<<pix
       //       <<"\t in hexagon channel:"<<ch<<",  ski="<<pixel_x<<"  Ch="<<pixel_y<<std::endl;
 

--- a/producers/cmshgcal/src/HexaBoardConverterPlugin.cc
+++ b/producers/cmshgcal/src/HexaBoardConverterPlugin.cc
@@ -128,7 +128,7 @@ namespace eudaq {
 	  const std::vector<std::array<unsigned int,1924>> decoded = decode_raw_32bit(rawData32, RDBOARD);
 
 	  // Here we parse the data per hexaboard and per ski roc and only leave meaningful data (Zero suppress and finding main frame):
-	  const std::vector<std::vector<unsigned short>> dataBlockZS = GetZSdata(decoded);
+	  const std::vector<std::vector<unsigned short>> dataBlockZS = GetZSdata(decoded, RDBOARD);
 
 	  for (unsigned h = 0; h < dataBlockZS.size(); h++){
 
@@ -358,7 +358,7 @@ namespace eudaq {
 	}
       */
 
-      std::vector<std::vector<unsigned short>> GetZSdata(const std::vector<std::array<unsigned int,1924>> &decoded) const{
+    std::vector<std::vector<unsigned short>> GetZSdata(const std::vector<std::array<unsigned int,1924>> &decoded, const int board_id) const{
 
 	//std::cout<<"In GetZSdata() method"<<std::endl;
 
@@ -366,7 +366,7 @@ namespace eudaq {
 	const int nHexa =  nSki/4;
 	if (nSki%4!=0)
 	  EUDAQ_WARN("Number of SkiRocs is not right: "+ eudaq::to_string(nSki));
-	if (nHexa != nSkiPerBoard/4)
+	if (nHexa != nSkiPerBoard[board_id-2]/4)
 	  EUDAQ_WARN("Number of HexaBoards is not right: "+ eudaq::to_string(nHexa));
 
 	// A vector per HexaBoard of vector of Hits from 4 ski-rocs


### PR DESCRIPTION
This commit should enable showing different number of Hexaboards per readout board.  In our case it's 4 and 6 at the moment.

Also, it includes some minor changes:
 * Masked more noisy channels 
 * Range of nHits plot for AHCAL was increased from 20 to 50
