### PR TITLE
Save all TDC hits in DWC producer

### DIFF
--- a/producers/cmshgcal/conf/AllInOneProducer.conf
+++ b/producers/cmshgcal/conf/AllInOneProducer.conf
@@ -111,7 +111,7 @@ AHCALBXIDWidth = 160
 
 
 [Producer.DWCs]
-dataFilePrefix = "../data/dwc_run_"
+dataFilePrefix = "/home/cmsdaq/DAQ/eudaq/data/data/dwc_run_"
 AcquisitionMode = 1
 
 

--- a/producers/cmshgcal/conf/AllInOneProducer.conf
+++ b/producers/cmshgcal/conf/AllInOneProducer.conf
@@ -124,8 +124,8 @@ edgeDetectionMode = 2
 timeResolution = 3
 maxHitsPerEvent = 9
 enabledChannels = 0xFFFF
-windowWidth = 60
-windowOffset = -30
+windowWidth = 0x40
+windowOffset = -10
 
 
 defaultTimestamp = -999

--- a/producers/cmshgcal/conf/AllInOneProducer.conf
+++ b/producers/cmshgcal/conf/AllInOneProducer.conf
@@ -124,8 +124,8 @@ edgeDetectionMode = 2
 timeResolution = 3
 maxHitsPerEvent = 9
 enabledChannels = 0xFFFF
-windowWidth = 0x400
-windowOffset = -100
+windowWidth = 60
+windowOffset = -30
 
 
 defaultTimestamp = -999

--- a/producers/cmshgcal_dwc/include/Unpacker.h
+++ b/producers/cmshgcal_dwc/include/Unpacker.h
@@ -18,7 +18,9 @@
 struct tdcData {
   int event;
   int ID;
-  std::map<unsigned int, unsigned int> timeOfArrivals;
+  std::map<unsigned int, unsigned int> timeOfArrivals;  //like in September 2016 test-beam: minimum of all read timestamps 
+  std::map<unsigned int, std::vector<unsigned int> >hits;
+
 } ;
 
 #define DEBUG_BOARD 0
@@ -30,7 +32,7 @@ class Unpacker {
     
   private:
     int Unpack (std::vector<WORD>) ;
-    std::map<unsigned int, std::vector<unsigned int> > timeStamps;   //like in September 2016 test-beam: minimum of all read timestamps
+    std::map<unsigned int, std::vector<unsigned int> > timeStamps;   
     tdcData currentData;
     int N_channels;
 };

--- a/producers/cmshgcal_dwc/src/CAEN_v1290.cc
+++ b/producers/cmshgcal_dwc/src/CAEN_v1290.cc
@@ -140,10 +140,11 @@ int CAEN_V1290::SetupModule() {
     eudaq::mSleep(20);
   }
   
-  eudaq::mSleep(100);
-  std::cout << "[CAEN_V1290]::[INFO]::Setting max hits per trigger " << configuration_.maxHitsPerEvent << std::endl;
-  status |= OpWriteTDC(CAEN_V1290_MAXHITS_OPCODE); 
-  status |= OpWriteTDC(configuration_.maxHitsPerEvent); 
+  //number of hits unlimited for July 2017 data taking (14.07.2017) 
+  //eudaq::mSleep(100);
+  //std::cout << "[CAEN_V1290]::[INFO]::Setting max hits per trigger " << configuration_.maxHitsPerEvent << std::endl;
+  //status |= OpWriteTDC(CAEN_V1290_MAXHITS_OPCODE); 
+  //status |= OpWriteTDC(configuration_.maxHitsPerEvent); 
   
   
   eudaq::mSleep(100);

--- a/producers/cmshgcal_dwc/src/CAEN_v1290.cc
+++ b/producers/cmshgcal_dwc/src/CAEN_v1290.cc
@@ -140,10 +140,10 @@ int CAEN_V1290::SetupModule() {
     eudaq::mSleep(20);
   }
   
-  //eudaq::mSleep(100);
-  //std::cout << "[CAEN_V1290]::[INFO]::Setting max hits per trigger " << configuration_.maxHitsPerEvent << std::endl;
-  //status |= OpWriteTDC(CAEN_V1290_MAXHITS_OPCODE); 
-  //status |= OpWriteTDC(configuration_.maxHitsPerEvent); 
+  eudaq::mSleep(100);
+  std::cout << "[CAEN_V1290]::[INFO]::Setting max hits per trigger " << configuration_.maxHitsPerEvent << std::endl;
+  status |= OpWriteTDC(CAEN_V1290_MAXHITS_OPCODE); 
+  status |= OpWriteTDC(configuration_.maxHitsPerEvent); 
   
   
   eudaq::mSleep(100);
@@ -574,7 +574,8 @@ void CAEN_V1290::generatePseudoData(std::vector<WORD> &data) {
     unsigned int readout;
     readout=(unsigned int)(rand()%2500) + 75;
 
-    for (int N=0; N<20; N++) {
+    int N_hits = rand()%20;
+    for (int N=0; N<N_hits; N++) {
       bitStream = 0;
       bitStream = bitStream | 0<<28;
       bitStream = bitStream | channel<<21;

--- a/producers/cmshgcal_dwc/src/CAEN_v1290.cc
+++ b/producers/cmshgcal_dwc/src/CAEN_v1290.cc
@@ -572,7 +572,7 @@ void CAEN_V1290::generatePseudoData(std::vector<WORD> &data) {
     if (rand()%100 < 10) continue;  //ten percent change of no hit detection 
 
     unsigned int readout;
-    readout=(unsigned int)(rand()%250) + 75;
+    readout=(unsigned int)(rand()%2500) + 75;
 
     for (int N=0; N<20; N++) {
       bitStream = 0;

--- a/producers/cmshgcal_dwc/src/Unpacker.cc
+++ b/producers/cmshgcal_dwc/src/Unpacker.cc
@@ -74,6 +74,7 @@ tdcData Unpacker::ConvertTDCData(std::vector<WORD> Words) {
   
   for (int ch=0; ch<N_channels; ch++) {
     currentData.timeOfArrivals[ch] = -1;  //fill all 16 channels with a value indicating that no hit has been registered
+    currentData.hits[ch].clear();
   } 
 
   for(std::map<unsigned int, std::vector<unsigned int> >::iterator channelTimeStamps = timeStamps.begin(); channelTimeStamps != timeStamps.end(); ++channelTimeStamps) {
@@ -81,6 +82,10 @@ tdcData Unpacker::ConvertTDCData(std::vector<WORD> Words) {
     
     unsigned int this_channel = channelTimeStamps->first; 
     currentData.timeOfArrivals[this_channel] = *min_element(channelTimeStamps->second.begin(), channelTimeStamps->second.end());
+    currentData.hits[this_channel] = channelTimeStamps->second;
+    #ifdef DEBUG_UNPACKER
+      std::cout<<"Number of hits in channel: "<<this_channel<<" :  "<<currentData.hits[this_channel].size()<<std::endl;
+    #endif
   }
 
   return currentData;

--- a/producers/cmshgcal_dwc/src/WireChamberProducer.cxx
+++ b/producers/cmshgcal_dwc/src/WireChamberProducer.cxx
@@ -231,10 +231,10 @@ class WireChamberProducer : public eudaq::Producer {
       }
 
       //get the timestamp since start:
-      timeSinceStart = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - startTime).count();
+      timeSinceStart = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - startTime).count();
       outTree->Fill();
 
-      std::cout<<"+++ Event: "<<m_ev<<": "<<timeSinceStart<<" mu s +++"<<std::endl;
+      std::cout<<"+++ Event: "<<m_ev<<": "<<timeSinceStart<<" ms +++"<<std::endl;
       for (int channel=0; channel<N_channels; channel++) std::cout<<" "<<dwc_timestamps[channel]; std::cout<<std::endl;
 
       // ------


### PR DESCRIPTION
... instead of simply saving the first hit's timestamp. It might improve the offline position reconstruction.