### PR TITLE
[dwc producer] save trigger time stamp in microseconds

### DIFF
--- a/producers/cmshgcal_dwc/src/WireChamberProducer.cxx
+++ b/producers/cmshgcal_dwc/src/WireChamberProducer.cxx
@@ -240,10 +240,10 @@ class WireChamberProducer : public eudaq::Producer {
       }
 
       //get the timestamp since start:
-      timeSinceStart = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - startTime).count();
+      timeSinceStart = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - startTime).count();
       outTree->Fill();
 
-      std::cout<<"+++ Event: "<<m_ev<<": "<<timeSinceStart<<" ms +++"<<std::endl;
+      std::cout<<"+++ Event: "<<m_ev<<": "<<timeSinceStart/1000.<<" ms +++"<<std::endl;
       for (int channel=0; channel<N_channels; channel++) std::cout<<" "<<dwc_timestamps[channel]; std::cout<<std::endl;
 
       // ------
@@ -316,7 +316,7 @@ class WireChamberProducer : public eudaq::Producer {
     std::vector<std::vector<int> > dwc_hits;
     std::vector<int> channels;
     std::chrono::steady_clock::time_point startTime;
-    int timeSinceStart;
+    Long64_t timeSinceStart;
 
     int defaultTimestamp;
 


### PR DESCRIPTION
The accuracy of the saved trigger time stamp is increased through the usage of micro- instead of milliseconds in the DWC producer.