### PR TITLE
Correlate average TOA between hexaboards

### DIFF
--- a/main/lib/src/StandardEvent.cc
+++ b/main/lib/src/StandardEvent.cc
@@ -322,7 +322,7 @@ namespace eudaq {
       }
       m_result_pix = &m_temp_pix;
       
-    } else if (m_pix.size() == 30){ // Hexaboard data
+    } else if (m_pix.size() == 31){ // Hexaboard data
       m_temp_pix.resize(0);
       m_temp_x.resize(0);
       m_temp_y.resize(0);

--- a/monitors/cmshgcal_onlinemon/src/HexagonHistos.cc
+++ b/monitors/cmshgcal_onlinemon/src/HexagonHistos.cc
@@ -322,6 +322,8 @@ void HexagonHistos::Fill(const eudaq::StandardPlane &plane, int evNumber) {
 	sig_HG[ts] = plane.GetPixel(pix, ts+nSCA);
       }
 
+      //std::cout<<"Average TOA of the board ("<<_sensor<<","<<_id<<") is "<< plane.GetPixel(0, 30) << std::endl;
+
       // Suppress noizy Time Samples:
       sig_LG[9]  /= 10;
       sig_LG[10] /= 10;

--- a/producers/cmshgcal/src/HexaBoardConverterPlugin.cc
+++ b/producers/cmshgcal/src/HexaBoardConverterPlugin.cc
@@ -22,7 +22,7 @@ const size_t RAW_EV_SIZE_32 = 123160;
 const int nSCA=13;
 
 // Size of ZS data (per channel)
-const char hitSizeZS = 31;
+const char hitSizeZS = 32;
 
 namespace eudaq {
   
@@ -39,8 +39,6 @@ namespace eudaq {
       // You may extract information from the BORE and/or configuration
       // and store it in member variables to use during the decoding later.
       virtual void Initialize(const Event &bore, const Configuration &cnf) {
-	m_exampleparam = bore.GetTag("HeXa", 0);
-	m_runMode = 0;
 	
 #ifndef WIN32 // some linux Stuff //$$change
 	(void)cnf; // just to suppress a warning about unused parameter cnf
@@ -422,11 +420,11 @@ namespace eudaq {
 	return roll;
 	}
       */
-
-    std::vector<std::vector<unsigned short>> GetZSdata(const std::vector<std::array<unsigned int,1924>> &decoded, const int board_id) const{
-
+      
+      std::vector<std::vector<unsigned short>> GetZSdata(const std::vector<std::array<unsigned int,1924>> &decoded, const int board_id) const {
+	
 	//std::cout<<"In GetZSdata() method"<<std::endl;
-
+	
 	const int nSki  =  decoded.size();
 	const int nHexa =  nSki/4;
 	if (nSki%4!=0)
@@ -439,6 +437,9 @@ namespace eudaq {
 	// A vector per HexaBoard of vector of Hits from 4 ski-rocs
 	std::vector<std::vector<unsigned short>> dataBlockZS(nHexa);
 
+	unsigned int toa_sum = 0;
+	unsigned int n_toa_fired = 0;
+	      
 	for (int ski = 0; ski < nSki; ski++ ){
 	  const int hexa = ski/4;
 
@@ -629,6 +630,11 @@ namespace eudaq {
 	    if (adc==0) adc=4096;
 	    dataBlockZS[hexa].push_back(adc);
 
+	    // Summing all TOA values of the pixels which fire it (to do average later)
+	    if (adc!=4){
+	      toa_sum += adc;
+	      n_toa_fired += 1;
+	    }
 	    // Filling TOA (stop rising clock)
 	    adc = gray_to_brady(decoded[ski][1664 + 64 + chArrPos] & 0x0FFF);
 	    if (adc==0) adc=4096;
@@ -644,8 +650,11 @@ namespace eudaq {
 	    if (adc==0) adc=4096;
 	    dataBlockZS[hexa].push_back(adc);
 
+	    // This frame is reserved to hold per-module variables.
+	    // (which are set outside of this loop):
+	    dataBlockZS[hexa].push_back(-1);
 
-
+	    
 	    /* Let's not save this for the moment (no need)
 
 	    // Global TS 14 MSB (it's gray encoded?). Not decoded here!
@@ -662,7 +671,16 @@ namespace eudaq {
 
 	  }
 
+	  if (ski%4==3 && toa_sum > 0 && n_toa_fired > 0){
+	    // Put here the average TOA value of the hexaboard
+	    dataBlockZS[hexa][31] = toa_sum/n_toa_fired;
+	    // Reset them:
+	    toa_sum = 0;
+	    n_toa_fired = 0;
+	  }
+
 	}
+	
 	return dataBlockZS;
 
       }
@@ -680,11 +698,9 @@ namespace eudaq {
       // in order to register this converter for the corresponding conversions
       // Member variables should also be initialized to default values here.
       HexaBoardConverterPlugin()
-	: DataConverterPlugin(EVENT_TYPE), m_exampleparam(0) {}
+	: DataConverterPlugin(EVENT_TYPE) {}
 
       // Information extracted in Initialize() can be stored here:
-      unsigned m_exampleparam;
-
       uint32_t m_skiMask[5];
 
       int m_runMode;

--- a/producers/cmshgcal/src/HexaBoardConverterPlugin.cc
+++ b/producers/cmshgcal/src/HexaBoardConverterPlugin.cc
@@ -652,7 +652,7 @@ namespace eudaq {
 
 	    // This frame is reserved to hold per-module variables.
 	    // (which are set outside of this loop):
-	    dataBlockZS[hexa].push_back(-1);
+	    dataBlockZS[hexa].push_back(0);
 
 	    
 	    /* Let's not save this for the moment (no need)


### PR DESCRIPTION
This pull should contain all changes needed for the requested TOA correlation plot.
So far I implemented the average TOA calculation in the Converter plugin, which is saved at position [31] of the array (the last entry of the first saved pixel).
